### PR TITLE
fixed issue with border appearing in smallest window size that makes header look awkward.

### DIFF
--- a/assets/css/secret-santa.css
+++ b/assets/css/secret-santa.css
@@ -35,6 +35,13 @@ body {
     padding-left: 20px;
     padding-right: 20px;
   }
+  /* Fix issue with header image not going all the way to the edge on mobile */
+  #wrap {
+    margin-left: -20px;
+    margin-right: -20px;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
 }
 
 


### PR DESCRIPTION
Fixed issue with border appearing in smallest window size that makes header look awkward. I wasn't sure if you want the header image to scale for mobile or not. So I didn't mess with that.
